### PR TITLE
feat(created edit profile page components): designed profile image with buttons

### DIFF
--- a/public/locales/ar/editprofile.json
+++ b/public/locales/ar/editprofile.json
@@ -1,0 +1,6 @@
+{
+    "editProfile": "تعديل الملف الشخصي",
+    "uploadNew": "تحميل جديد",
+    "chooseFromLibrary": "اختيار من المكتبة",
+    "saveChanges": "حفظ التغييرات"
+}

--- a/public/locales/en/editprofile.json
+++ b/public/locales/en/editprofile.json
@@ -1,0 +1,6 @@
+{
+    "editProfile": "Edit Profile",
+    "uploadNew": "Upload New",
+    "chooseFromLibrary": "Choose From Library",
+    "saveChanges": "Save Changes"
+}

--- a/src/components/CircleImg.jsx
+++ b/src/components/CircleImg.jsx
@@ -1,0 +1,11 @@
+const CircleImg = () => {
+    return (
+        <div className='w-2/12 '>
+            <div className='flex items-center justify-center w-32 h-32 md:w-36 md:h-36 lg:w-64 lg:h-64 rounded-full bg-black-100 text-white text-3xl font-bold'>
+                <span className=''>R</span>
+            </div>
+        </div>
+    );
+};
+
+export default CircleImg;

--- a/src/components/EditProfileButton.jsx
+++ b/src/components/EditProfileButton.jsx
@@ -1,0 +1,23 @@
+import { Button } from "react-flatifycss";
+
+const EditprofileButton = ({ text }) => {
+    const styles = {
+        backgroundColor: "white",
+        border: "2px solid black",
+        borderRadius: "0.5rem",
+        boxShadow: "2px 2px #1a1a1a",
+    };
+    return (
+        <div className=' w-1/3 flex justify-center lg:py-3 lg:px-3 md:py-2 md:px-2 sm:py-1 sm:px-2  '>
+            <Button style={styles} className='w-full h-16 px-1 transition '>
+                <div className='relative flex items-center space-x-4 justify-center'>
+                    <span className='block w-max font-semibold tracking-wide text-gray-900 sm:text-base text-sm md:text-lg lg:text-xl '>
+                        {text}
+                    </span>
+                </div>
+            </Button>
+        </div>
+    );
+};
+
+export default EditprofileButton;

--- a/src/components/SaveButton.jsx
+++ b/src/components/SaveButton.jsx
@@ -1,0 +1,13 @@
+const SaveButton = ({ text, className }) => {
+    return (
+        <div className='px-3 py-2 lg:py-4 '>
+            <button
+                className={`w-36 h-16 lg:w-56 bg-primary-200  text-white font-semibold rounded-lg text-sm lg:text-md px-3 sm:px-5 py-3  ${className}`}
+            >
+                {text}
+            </button>
+        </div>
+    );
+};
+
+export default SaveButton;

--- a/src/components/__tests__/CircleImg.test.jsx
+++ b/src/components/__tests__/CircleImg.test.jsx
@@ -1,0 +1,8 @@
+import renderer from "react-test-renderer";
+
+import CircleImg from "@/components/CircleImg";
+
+it("renders correctly", () => {
+    const tree = renderer.create(<CircleImg />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/EditProfileButton.test.jsx
+++ b/src/components/__tests__/EditProfileButton.test.jsx
@@ -1,0 +1,8 @@
+import renderer from "react-test-renderer";
+
+import EditProfileButton from "@/components/EditProfileButton";
+
+it("renders correctly", () => {
+    const tree = renderer.create(<EditProfileButton />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/SaveButton.test.jsx
+++ b/src/components/__tests__/SaveButton.test.jsx
@@ -1,0 +1,8 @@
+import renderer from "react-test-renderer";
+
+import SaveButton from "@/components/SaveButton";
+
+it("renders correctly", () => {
+    const tree = renderer.create(<SaveButton />).toJSON();
+    expect(tree).toMatchSnapshot();
+});

--- a/src/components/__tests__/__snapshots__/CircleImg.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/CircleImg.test.jsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="w-2/12 "
+>
+  <div
+    className="flex items-center justify-center w-32 h-32 md:w-36 md:h-36 lg:w-64 lg:h-64 rounded-full bg-black-100 text-white text-3xl font-bold"
+  >
+    <span
+      className=""
+    >
+      R
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/__tests__/__snapshots__/EditProfileButton.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/EditProfileButton.test.jsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className=" w-1/3 flex justify-center lg:py-3 lg:px-3 md:py-2 md:px-2 sm:py-1 sm:px-2  "
+>
+  <button
+    className="button__ButtonWrapper-sc-1aw98b4-0 button w-full h-16 px-1 transition "
+    disabled={false}
+    style={
+      Object {
+        "backgroundColor": "white",
+        "border": "2px solid black",
+        "borderRadius": "0.5rem",
+        "boxShadow": "2px 2px #1a1a1a",
+      }
+    }
+  >
+    <div
+      className="relative flex items-center space-x-4 justify-center"
+    >
+      <span
+        className="block w-max font-semibold tracking-wide text-gray-900 sm:text-base text-sm md:text-lg lg:text-xl "
+      />
+    </div>
+  </button>
+</div>
+`;

--- a/src/components/__tests__/__snapshots__/SaveButton.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/SaveButton.test.jsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `
+<div
+  className="px-3 py-2 lg:py-4 "
+>
+  <button
+    className="w-36 h-16 lg:w-56 bg-primary-200  text-white font-semibold rounded-lg text-sm lg:text-md px-3 sm:px-5 py-3  undefined"
+  />
+</div>
+`;

--- a/src/pages/editprofile/index.jsx
+++ b/src/pages/editprofile/index.jsx
@@ -1,0 +1,44 @@
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+
+import CircleImg from "@/components/CircleImg";
+import EditprofileButton from "@/components/EditProfileButton";
+import SaveButton from "@/components/SaveButton";
+
+const EditProfile = () => {
+    const { t } = useTranslation("editprofile");
+
+    return (
+        <div className='flex flex-col md:px-14 px-4 lg:px-48  flex-wrap nowrap mt-8'>
+            <div className='flex justify-start py-3'>
+                <h3 className='font-semibold mb-8 tracking-tight text-gray-800 text-4xl order-first'>
+                    {t("editProfile")}
+                </h3>
+            </div>
+            <div className='flex flex-row items-center justify-between flex-wrap nowrap'>
+                <CircleImg />
+                <div className='w-1/4'>
+                    <SaveButton
+                        text={t("uploadNew")}
+                        className='lg:ml-16 tracking-widest'
+                    />
+                </div>
+                <EditprofileButton text={t("chooseFromLibrary")} />
+            </div>
+        </div>
+    );
+};
+
+export default EditProfile;
+
+export async function getStaticProps({ locale }) {
+    return {
+        props: {
+            ...(await serverSideTranslations(locale, [
+                "common",
+                "editprofile",
+            ])),
+            // Will be passed to the page component as props
+        },
+    };
+}


### PR DESCRIPTION
I designed components for the Edit Profile page that allow users to change their profile image using buttons, and make it responsive and easy to use on different screen sizes. and supports both Arabic and English languages.
Desktop:
![editprofilepageDesktop](https://user-images.githubusercontent.com/119085953/230613414-1d807371-731a-4809-b71a-52d00979ccf1.png)
Mobile:
![editprofilepageobilear](https://user-images.githubusercontent.com/119085953/230614187-35b7ac5f-faae-4e47-81cd-8b77ccafbac8.png)



